### PR TITLE
Update royalslider.css

### DIFF
--- a/zosim.me/royalslider.css
+++ b/zosim.me/royalslider.css
@@ -218,11 +218,11 @@
 
 img.rsImg {
 	max-width: none;
-	
+	margin-left:0px!important;
 }
 img.rsImg .rsMainSlideImage
 {
-mer:0;
+margin-left:0px!important;
 }
 /*
 .grab-cursor {


### PR DESCRIPTION
Added the `margin-left:0` to center the big pictures on links
Deleted the cursor file from repository

```
img.rsImg {
    max-width: none;
    margin-left:0px!important;
}
img.rsImg .rsMainSlideImage {
    margin-left:0px;
}
```
